### PR TITLE
remove existing reference to deleted tsconfig.json

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,7 +2,7 @@ FROM node
 
 WORKDIR /usr/src/app
 
-ADD package.json yarn.lock tsconfig.json ./
+ADD package.json yarn.lock ./
 RUN yarn install
 
 EXPOSE 4000


### PR DESCRIPTION
This was blowing up during `docker-compose up -d --build`, due to the file not
existing anymore, so removing the reference in the Dockerfile.